### PR TITLE
Guard spec.loadVolume access in doUpdate to avoid nil-index crash

### DIFF
--- a/UniversalAutoload.lua
+++ b/UniversalAutoload.lua
@@ -2585,32 +2585,37 @@ function UniversalAutoload:doUpdate(dt, isActiveForInput, isActiveForInputIgnore
 		spec.customOffset = spec.customOffset or 0
 		spec.customRotation = spec.customRotation or 0
 
-		local rotationshift = spec.loadVolume.length / 3
-		local direction = (spec.currentTipside == "right") and 1 or -1
-		local function clampOffset()
-			local minOffset = (spec.customRotation == 0) and 0 or rotationshift
-			local maxOffset = spec.loadVolume.length / 2 + minOffset
-			spec.customOffset = math.clamp(spec.customOffset, minOffset, maxOffset)
-		end
+		-- spec.loadVolume is only populated server-side by initialiseTransformGroups,
+		-- or for vehicles without a valid loadArea config. Skip the shift/rotate logic
+		-- in those cases to avoid "attempt to index nil with 'length'".
+		if spec.loadVolume then
+			local rotationshift = spec.loadVolume.length / 3
+			local direction = (spec.currentTipside == "right") and 1 or -1
+			local function clampOffset()
+				local minOffset = (spec.customRotation == 0) and 0 or rotationshift
+				local maxOffset = spec.loadVolume.length / 2 + minOffset
+				spec.customOffset = math.clamp(spec.customOffset, minOffset, maxOffset)
+			end
 
-		if spec.leftKeyPressed then
-			spec.customOffset = spec.customOffset - (UniversalAutoload.SHIFT_DELTA * direction)
-			clampOffset()
-		end
+			if spec.leftKeyPressed then
+				spec.customOffset = spec.customOffset - (UniversalAutoload.SHIFT_DELTA * direction)
+				clampOffset()
+			end
 
-		if spec.rightKeyPressed then
-			spec.customOffset = spec.customOffset + (UniversalAutoload.SHIFT_DELTA * direction)
-			clampOffset()
-		end
+			if spec.rightKeyPressed then
+				spec.customOffset = spec.customOffset + (UniversalAutoload.SHIFT_DELTA * direction)
+				clampOffset()
+			end
 
-		if spec.rotateKeyPressed then
-			local rotated = spec.customRotation ~= 0
+			if spec.rotateKeyPressed then
+				local rotated = spec.customRotation ~= 0
 
-			spec.customRotation = rotated and 0 or -math.pi / 2
-			spec.customOffset = spec.customOffset + (rotated and -rotationshift or rotationshift)
+				spec.customRotation = rotated and 0 or -math.pi / 2
+				spec.customOffset = spec.customOffset + (rotated and -rotationshift or rotationshift)
 
-			spec.rotateKeyPressed = false
-			clampOffset()
+				spec.rotateKeyPressed = false
+				clampOffset()
+			end
 		end
 
 	end


### PR DESCRIPTION
## Problem

`doUpdate` crashes for vehicles where `spec.loadVolume` is nil — either on a multiplayer client (where `initialiseTransformGroups` never runs because it's gated on `self.isServer`) or for vehicles UAL detects as autoload-capable but that lack a configured `loadArea`. The `pcall` in `onUpdate` / `onUpdateTick` catches it, prints `UAL - FATAL ERROR: <vehicle>` once, and permanently disables UAL on that vehicle for the rest of the session.

Example log entries:

```
UAL - FATAL ERROR: TRAIL_KING Trailking 70HDG
UniversalAutoload.lua:2588: attempt to index nil with 'length'
UAL - FATAL ERROR: Phiber Tote Deck
UniversalAutoload.lua:2588: attempt to index nil with 'length'
```

## Root cause

`spec.loadVolume` is only created in `initialiseTransformGroups`, called from `onLoad` only when:

```lua
if self.isServer and self.propertyState ~= VehiclePropertyState.SHOP_CONFIG then
    ...
    UniversalAutoload.initialiseTransformGroups(self)
end
```

So on a multiplayer client `spec.loadVolume` is always nil; on the server it's also nil whenever a vehicle has no valid `loadArea` config. The customOffset/customRotation block in `doUpdate` dereferences `spec.loadVolume.length` unconditionally (lines 2588 and 2592), hence the crash.

## Fix

Wrap the offset/rotation block with `if spec.loadVolume then ... end`. The action-event update block above it (toggle loading, cycle material, etc.) does not depend on `loadVolume` and continues to run. No behavior change for vehicles where `loadVolume` is correctly populated.