### PR TITLE
Fix multiplayer event relay for vehicle state changes

### DIFF
--- a/events/PlayerTriggerEvent.lua
+++ b/events/PlayerTriggerEvent.lua
@@ -49,6 +49,9 @@ function PlayerTriggerEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		--print("PLAYER IN TRIGGER: "..tostring(self.inTrigger))
 		UniversalAutoload.updatePlayerTriggerState(self.vehicle, self.player, self.inTrigger, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/RaiseActiveEvent.lua
+++ b/events/RaiseActiveEvent.lua
@@ -39,6 +39,9 @@ function RaiseActiveEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		--print("RAISE ACTIVE "..tostring(self.inTrigger))
 		UniversalAutoload.forceRaiseActive(self.vehicle, self.state, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/ResetLoadingEvent.lua
+++ b/events/ResetLoadingEvent.lua
@@ -28,6 +28,9 @@ end
 function ResetLoadingEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.resetLoadingState(self.vehicle, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/SetCollectionModeEvent.lua
+++ b/events/SetCollectionModeEvent.lua
@@ -31,6 +31,9 @@ end
 function SetCollectionModeEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.setAutoCollectionMode(self.vehicle, self.autoCollectionMode, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/SetContainerTypeEvent.lua
+++ b/events/SetContainerTypeEvent.lua
@@ -31,6 +31,9 @@ end
 function SetContainerTypeEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.setContainerTypeIndex(self.vehicle, self.typeIndex, true) 
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/SetFilterEvent.lua
+++ b/events/SetFilterEvent.lua
@@ -31,6 +31,9 @@ end
 function SetFilterEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.setLoadingFilter(self.vehicle, self.state, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/SetHorizontalLoadingEvent.lua
+++ b/events/SetHorizontalLoadingEvent.lua
@@ -31,6 +31,9 @@ end
 function SetHorizontalLoadingEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.setHorizontalLoading(self.vehicle, self.state, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/SetLoadsideEvent.lua
+++ b/events/SetLoadsideEvent.lua
@@ -31,6 +31,9 @@ end
 function SetLoadsideEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.setCurrentLoadside(self.vehicle, self.loadside, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/SetMaterialTypeEvent.lua
+++ b/events/SetMaterialTypeEvent.lua
@@ -31,6 +31,9 @@ end
 function SetMaterialTypeEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.setMaterialTypeIndex(self.vehicle, self.typeIndex, true) 
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/SetTipsideEvent.lua
+++ b/events/SetTipsideEvent.lua
@@ -31,6 +31,9 @@ end
 function SetTipsideEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.setCurrentTipside(self.vehicle, self.tipside, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/StartLoadingEvent.lua
+++ b/events/StartLoadingEvent.lua
@@ -31,6 +31,9 @@ end
 function StartLoadingEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.startLoading(self.vehicle, self.force, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/StopLoadingEvent.lua
+++ b/events/StopLoadingEvent.lua
@@ -31,6 +31,9 @@ end
 function StopLoadingEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.stopLoading(self.vehicle, self.force, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/events/UnloadingEvent.lua
+++ b/events/UnloadingEvent.lua
@@ -31,6 +31,9 @@ end
 function StartUnloadingEvent:run(connection)
 	if self.vehicle ~= nil and self.vehicle:getIsSynchronized() then
 		UniversalAutoload.startUnloading(self.vehicle, self.force, true)
+		if not connection:getIsServer() then
+			g_server:broadcastEvent(self, false, connection, self.vehicle)
+		end
 	end
 end
 

--- a/tests/unit/test_multiplayer_event_relay.py
+++ b/tests/unit/test_multiplayer_event_relay.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+
+
+EVENT_CASES = (
+    ("PlayerTriggerEvent.lua", "PlayerTriggerEvent", "updatePlayerTriggerState", "vehicle, 7, true"),
+    ("RaiseActiveEvent.lua", "RaiseActiveEvent", "forceRaiseActive", "vehicle, true"),
+    ("ResetLoadingEvent.lua", "ResetLoadingEvent", "resetLoadingState", "vehicle"),
+    (
+        "SetCollectionModeEvent.lua",
+        "SetCollectionModeEvent",
+        "setAutoCollectionMode",
+        "vehicle, true",
+    ),
+    ("SetContainerTypeEvent.lua", "SetContainerTypeEvent", "setContainerTypeIndex", "vehicle, 2"),
+    ("SetFilterEvent.lua", "SetFilterEvent", "setLoadingFilter", "vehicle, true"),
+    (
+        "SetHorizontalLoadingEvent.lua",
+        "SetHorizontalLoadingEvent",
+        "setHorizontalLoading",
+        "vehicle, true",
+    ),
+    ("SetLoadsideEvent.lua", "SetLoadsideEvent", "setCurrentLoadside", 'vehicle, "left"'),
+    ("SetMaterialTypeEvent.lua", "SetMaterialTypeEvent", "setMaterialTypeIndex", "vehicle, 2"),
+    ("SetTipsideEvent.lua", "SetTipsideEvent", "setCurrentTipside", 'vehicle, "left"'),
+    ("StartLoadingEvent.lua", "StartLoadingEvent", "startLoading", "vehicle, true"),
+    ("StopLoadingEvent.lua", "StopLoadingEvent", "stopLoading", "vehicle, true"),
+    ("UnloadingEvent.lua", "StartUnloadingEvent", "startUnloading", "vehicle, true"),
+)
+
+
+@unittest.skipUnless(shutil.which("lua5.1"), "lua5.1 is required")
+class MultiplayerEventRelayTests(unittest.TestCase):
+    def test_client_requests_are_relayed_to_other_clients(self) -> None:
+        for filename, event_name, mutation_name, constructor_args in EVENT_CASES:
+            with self.subTest(event=event_name):
+                event_path = REPOSITORY / "events" / filename
+                script = f"""
+UniversalAutoload = {{}}
+Event = {{}}
+
+function Class(classTable, baseClass)
+    return {{__index = classTable}}
+end
+
+function Event.new(metaTable)
+    return setmetatable({{}}, metaTable)
+end
+
+function InitEventClass(classTable, name)
+end
+
+local mutationCalls = 0
+local mutationArguments = nil
+UniversalAutoload.{mutation_name} = function(...)
+    mutationCalls = mutationCalls + 1
+    mutationArguments = {{...}}
+end
+
+local vehicle = {{
+    synchronized = true,
+    getIsSynchronized = function(self)
+        return self.synchronized
+    end
+}}
+
+local clientConnection = {{
+    getIsServer = function(self)
+        return false
+    end
+}}
+
+local serverConnection = {{
+    getIsServer = function(self)
+        return true
+    end
+}}
+
+local broadcastCalls = 0
+local relayedEvent = nil
+local excludedConnection = nil
+local relatedObject = nil
+local sendLocal = nil
+g_server = {{
+    broadcastEvent = function(self, event, localDelivery, excluded, object)
+        broadcastCalls = broadcastCalls + 1
+        relayedEvent = event
+        sendLocal = localDelivery
+        excludedConnection = excluded
+        relatedObject = object
+    end
+}}
+
+dofile({event_path.as_posix()!r})
+
+local event = UniversalAutoload.{event_name}.new({constructor_args})
+event:run(clientConnection)
+
+assert(mutationCalls == 1, "the server should apply the request once")
+assert(mutationArguments[1] == vehicle, "the request should target the decoded vehicle")
+assert(mutationArguments[#mutationArguments] == true, "the relayed mutation should suppress another send")
+assert(broadcastCalls == 1, "the server should relay a client request")
+assert(relayedEvent == event, "the server should relay the accepted event")
+assert(sendLocal == false, "the server should not run the accepted event twice")
+assert(excludedConnection == clientConnection, "the requesting client already applied the change")
+assert(relatedObject == vehicle, "the relay should use the vehicle for network relevance")
+
+event:run(serverConnection)
+assert(mutationCalls == 2, "a server event should still be applied by a client")
+assert(broadcastCalls == 1, "a client must not relay an event received from the server")
+
+vehicle.synchronized = false
+event:run(clientConnection)
+assert(mutationCalls == 2, "an unsynchronized vehicle should be ignored")
+assert(broadcastCalls == 1, "an invalid request should not be relayed")
+"""
+                result = subprocess.run(
+                    ["lua5.1", "-"],
+                    input=script,
+                    text=True,
+                    capture_output=True,
+                    cwd=REPOSITORY,
+                    check=False,
+                )
+                self.assertEqual(
+                    result.returncode,
+                    0,
+                    msg=f"{event_name} relay contract failed:\n{result.stderr}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Client-originated Universal Autoload events were being applied by the server but were not forwarded to the other connected clients. This could leave players with different loading states or vehicle settings during a multiplayer session.

The server now relays these events to the other clients after applying them:

- Player trigger state
- Active state
- Loading reset
- Collection mode
- Container type
- Material and container filters
- Horizontal loading
- Load side
- Tip side
- Start and stop loading
- Start unloading

The client that sent the request is excluded from the relay because it has already applied the change locally. The vehicle is supplied as the event's relevance object so the event is only sent where appropriate.

Cycle actions were left unchanged because the server already turns them into the corresponding set event, which is covered by this change.

## Testing

- All Lua files passed Lua 5.1 syntax validation.
- All 164 unit tests passed.
- Added regression coverage for all 13 affected event types, including:
  - client-to-server requests being relayed to other clients;
  - the sending client being excluded;
  - server events not being echoed back to the server;
  - events for unsynchronised vehicles being ignored.
- The packaged mod passed file and reference validation.
- The exact package was loaded on an FS25 1.21 dedicated server:
  - the network game started successfully;
  - Universal Autoload loaded and entered gameplay;
  - no Universal Autoload errors, warnings, or Lua stack traces were reported.

A full client-to-client test still needs two licensed game clients connected to the same server. The automated regression tests cover the relay direction and event arguments, while the dedicated-server run confirms that the package loads cleanly on FS25 1.21.
